### PR TITLE
fix: linkedin links

### DIFF
--- a/components/linkedin-feedback/constants.ts
+++ b/components/linkedin-feedback/constants.ts
@@ -6,6 +6,7 @@ export const LINKEDIN_FEEDBACK_LIST: TLinkedinFeedback[] = [
       name: 'Roman Kolisnyk ',
       position: 'Frontend UI Lead',
       avatar: '/static/images/about/kolisnyk.jpeg',
+      linkedinLink: 'https://www.linkedin.com/in/ramapitek/',
       company: {
         name: 'AirSlate',
         url: 'https://www.airslate.com/',
@@ -17,9 +18,9 @@ export const LINKEDIN_FEEDBACK_LIST: TLinkedinFeedback[] = [
   {
     author: {
       name: 'Oleksandr Holovchenko',
-      avatar:
-        '/static/images/about/holovchenko.jpeg',
+      avatar: '/static/images/about/holovchenko.jpeg',
       position: 'Software Engineer',
+      linkedinLink: 'https://www.linkedin.com/in/algolj/',
       company: {
         name: 'MacPaw',
         url: 'https://macpaw.com/',
@@ -32,8 +33,8 @@ export const LINKEDIN_FEEDBACK_LIST: TLinkedinFeedback[] = [
     author: {
       name: 'Anton Slesariev',
       position: 'Senior Frontend Engineer',
-      avatar:
-        '/static/images/about/slesariev.jpeg',
+      avatar: '/static/images/about/slesariev.jpeg',
+      linkedinLink: 'https://www.linkedin.com/in/sonarct/',
       company: {
         name: 'Readdle',
         url: 'https://readdle.com/',

--- a/components/linkedin-feedback/linkedin-feedback.tsx
+++ b/components/linkedin-feedback/linkedin-feedback.tsx
@@ -26,9 +26,15 @@ function LinkedinFeedback(props: Props) {
                 />
 
                 <div className="flex flex-col ml-3">
-                  <span className="text-gray-700 dark:text-gray-300">
-                    {feedback.author.name}
-                  </span>
+                  <a
+                    href={feedback.author.linkedinLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <h3 className='not-prose'>
+                      {feedback.author.name}
+                    </h3>
+                  </a>
                   <p className="m-0 text-gray-700 dark:text-gray-300 text-xs">
                     {`${feedback.author.position} `}
                     <a

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -69,6 +69,7 @@ type LinkedinFeedbackAuthor = {
   position: string;
   avatar: string;
   company: LinkedinCompany;
+  linkedinLink: string;
 };
 
 export type TLinkedinFeedback = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Author names in LinkedIn feedback are now clickable links that open the author’s LinkedIn profile in a new tab.
  * Added LinkedIn profile links for featured authors, enabling quick access to their professional profiles directly from the feedback section.
  * Improved accessibility and security with proper link behaviors (new tab and safe rel attributes).
  * Enhanced the author data to include LinkedIn URLs, ensuring consistent display of profile links across the feedback component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->