### PR TITLE
perf(blog): use metadata-only queries in category page

### DIFF
--- a/_posts/build-time-lies.md
+++ b/_posts/build-time-lies.md
@@ -1,0 +1,151 @@
+---
+title: 'I Fixed the Wrong Thing and Found the Real Bug'
+heading: 'Total Build Time Lies'
+description: I spotted a build regression, shipped what I thought was the fix, and the numbers didn't move. Turns out the metrics were lying too — Next.js reports batch timing, not page timing.
+createDate: 2026-04-17T22:00:00.000Z
+keywords:
+  [
+    Next.js build performance,
+    build time regression,
+    Shiki highlighting performance,
+    static generation optimization,
+    Vercel build logs,
+  ]
+categories: [ Opinion, Tools, Vercel ]
+featured: false
+---
+
+## The number that didn't move
+
+I pushed a routine update to my portfolio — swapped Prettier for [oxfmt](https://github.com/nicolo-ribaudo/oxfmt),
+added [`@shikijs/transformers`](https://shiki.style/packages/transformers) for better syntax highlighting. Stack is
+Next.js 16, Turbopack, Prisma, Sentry, Vercel, pnpm. Nothing unusual.
+
+Checked the Vercel build log. Total build time: 48 seconds. Ran two more deploys to be sure. 47 seconds. 48 seconds.
+Flat line.
+
+I almost closed the tab.
+
+Then I scrolled down to the per-page breakdown. Completely different story.
+
+## Two changes, opposite directions
+
+The listing pages — homepage, blog index, snippets — got much faster:
+
+| Route       | Before   | After  |
+|-------------|----------|--------|
+| `/`         | 7,046 ms | 487 ms |
+| `/blog`     | 7,116 ms | 664 ms |
+| `/snippets` | 7,046 ms | 547 ms |
+
+Roughly a 13x improvement. But the total build time didn't budge. Something else got worse by the same amount.
+
+That something was `/blog/category/[category]`.
+
+| Metric           | Before       | After        |
+|------------------|--------------|--------------|
+| Route total      | ~15.8 s      | ~45.8 s      |
+| Slowest category | ~1,000 ms    | ~6,600 ms    |
+| Typical range    | 900–1,100 ms | 500–6,600 ms |
+
+Six categories jumped from about a second to 6.6 seconds each: `html`, `clean-code`, `project-setup`, `node`, `react`,
+`advanced-react`. The rest stayed put. A 20-second improvement on listing pages masked a 30-second regression on
+category pages. Near-perfect cancellation.
+
+An accidental coincidence that made the top-line number useless.
+
+## The wrong fix
+
+Three deploys. Same six slow categories. Same order of magnitude. Not noise.
+
+The six categories had something in common — they were the six with the most posts. Whatever was slow, it scaled with
+post count.
+
+My hypothesis: the category page was fetching full post content — markdown body included — when it only needed metadata.
+A listing page shows titles, descriptions, and links. It doesn't render post bodies. If the data-fetching function
+pulled full content, it was doing unnecessary work.
+
+I checked the code. `getPostsByCategory` called `getPosts`, which reads every post file and returns the body. The
+category page never used the body. I switched it to `getPostsMetadata` — slug, title, description. No body. Two files,
+28 lines changed.
+
+Deployed. Checked the build log.
+
+Numbers didn't move. Same six categories. Same 6,600ms each.
+
+## The actual problem
+
+I stared at the build log longer and noticed something I'd skipped over. Look at these two routes:
+
+```bash
+/blog/[slug]                     (43168 ms)
+  /blog/ai-seo-audit             (6663 ms)
+  /blog/apollo-graphql-certification (6663 ms)
+
+/blog/category/[category]        (45771 ms)
+  /blog/category/html            (6663 ms)
+  /blog/category/clean-code      (6663 ms)
+```
+
+Blog posts and category pages both showing exactly 6,663ms. Not approximately — _exactly_. Different routes, different
+code paths, identical timing.
+
+Next.js generates static pages in batches. The per-page time in the build log is the batch wall-clock time, not the
+individual page time. Every page in a batch gets assigned the same number — the slowest page in that batch.
+
+My category pages were fast. They were just stuck in the same batch as Shiki-heavy blog post compilations. The metadata
+fix was correct code hygiene — don't fetch content you don't need — but it couldn't change the batch timing because the
+category pages weren't the bottleneck in their batch. The blog posts were.
+
+## The real bottleneck
+
+So why were the blog posts slow? I dug into the Shiki integration.
+
+Every `compileMDX` call created a new `rehypeShiki` plugin instance. Each instance initialized a fresh Shiki
+highlighter — loading the WASM engine, two themes, and grammars for every bundled language. 75 pages = 75 highlighter
+initializations.
+
+The fix: use `@shikijs/rehype/core` with a single pre-created highlighter at module level.
+
+```typescript
+import rehypeShikiFromHighlighter from '@shikijs/rehype/core';
+import { bundledLanguages, getSingletonHighlighter } from 'shiki';
+
+const highlighterPromise = getSingletonHighlighter({
+  themes: ['github-light', 'github-dark'],
+  langs: Object.keys(bundledLanguages),
+});
+
+const highlightCache = new Map();
+```
+
+Themes and language grammars load once. A shared `Map` caches highlighted code blocks across pages. The pre-created
+highlighter gets passed directly to each `compileMDX` call instead of creating a new one.
+
+The category route dropped from 45.8s to 2.8s. Most categories now generate in under 363ms. But — honesty note — the "
+before" was measured on Vercel with 1 worker and the "after" was local with 13 workers. Two variables changed, not one.
+I trust the direction, not the exact ratio.
+
+## Three things I got wrong
+
+First, I thought the category page was the problem. It wasn't — it was innocent bystander in a slow batch.
+
+Second, I thought `getPostsMetadata` vs `getPosts` was the fix. It was good code, but it didn't address the timing. I
+was looking at the right page and the wrong metric.
+
+Third, I assumed per-page timing in the build log meant per-page timing. It means per-batch timing. Every page in a
+batch gets the same number. If you're comparing page performance across builds, you're comparing batch composition and
+scheduling as much as you're comparing the page itself.
+
+## The numbers you actually need
+
+Total build time is the number everyone watches. It's on the dashboard. It's in the Slack notification. It's the number
+you compare week over week.
+
+It's also an aggregate, and aggregates lie by averaging. My total build time held steady at 48 seconds while a 30-second
+per-route regression hid behind an equally sized improvement somewhere else.
+
+And when I looked at the per-page numbers, those lied too — just differently. They told me which pages were slow. They
+didn't tell me those pages were _fast_, just stuck behind slow neighbors.
+
+I ended up fixing the right thing for the wrong reason. I'll take it.

--- a/_posts/build-time-lies.md
+++ b/_posts/build-time-lies.md
@@ -71,13 +71,13 @@ category page never used the body. I switched it to `getPostsMetadata` — slug,
 
 Deployed. Checked the build log.
 
-Numbers didn't move. Same six categories. Same 6,600ms each.
+**Numbers didn't move.** Same six categories. Same 6,600ms each.
 
 ## The actual problem
 
 I stared at the build log longer and noticed something I'd skipped over. Look at these two routes:
 
-```bash
+```text
 /blog/[slug]                     (43168 ms)
   /blog/ai-seo-audit             (6663 ms)
   /blog/apollo-graphql-certification (6663 ms)
@@ -87,8 +87,8 @@ I stared at the build log longer and noticed something I'd skipped over. Look at
   /blog/category/clean-code      (6663 ms)
 ```
 
-Blog posts and category pages both showing exactly 6,663ms. Not approximately — _exactly_. Different routes, different
-code paths, identical timing.
+Blog posts and category pages both showing exactly 6,663ms. Not approximately — _exactly_.
+Different routes, different code paths, identical timing.
 
 Next.js generates static pages in batches. The per-page time in the build log is the batch wall-clock time, not the
 individual page time. Every page in a batch gets assigned the same number — the slowest page in that batch.
@@ -102,8 +102,9 @@ category pages weren't the bottleneck in their batch. The blog posts were.
 So why were the blog posts slow? I dug into the Shiki integration.
 
 Every `compileMDX` call created a new `rehypeShiki` plugin instance. Each instance initialized a fresh Shiki
-highlighter — loading the WASM engine, two themes, and grammars for every bundled language. 75 pages = 75 highlighter
-initializations.
+highlighter — loading the WASM engine, two themes, and grammars for every bundled language.
+
+**75 pages = 75 highlighter initializations.**
 
 The fix: use `@shikijs/rehype/core` with a single pre-created highlighter at module level.
 
@@ -133,7 +134,12 @@ Same Vercel infrastructure, same 1 worker:
 
 The category route dropped from 45.8s to 7.4s. Individual categories went from 6,663ms to 461ms. Static generation cut in half.
 
-You might notice those route totals don't add up. Before the fix, `/blog/[slug]` showed 43s, `/blog/category` showed 45s, `/snippets` showed 14s — that's 102 seconds of work. But actual static generation took 13.4s. The route times are concurrent, not sequential. Next.js generates multiple routes at the same time; each route's clock runs in parallel. The total build went from 46s to 42s because static generation is only one piece — TypeScript checking, Turbopack compilation, and Sentry uploads don't get faster when you fix Shiki.
+You might notice those route totals don't add up. Before the fix, `/blog/[slug]` showed 43s, `/blog/category` showed
+45s, `/snippets` showed 14s — that's 102 seconds of work. But actual static generation took 13.4s. The route times are
+concurrent, not sequential. Next.js generates multiple routes at the same time; each route's clock runs in parallel.
+
+The total build went from 46s to 42s because static generation is only one piece — TypeScript checking, Turbopack
+compilation, and Sentry uploads don't get faster when you fix Shiki.
 
 ## Three things I got wrong
 

--- a/_posts/build-time-lies.md
+++ b/_posts/build-time-lies.md
@@ -11,7 +11,7 @@ keywords:
     static generation optimization,
     Vercel build logs,
   ]
-categories: [Opinion, Tools, Vercel]
+categories: [ Opinion, Tools, Vercel ]
 featured: false
 ---
 
@@ -33,7 +33,7 @@ Then I scrolled down to the per-page breakdown. Completely different story.
 The listing pages — homepage, blog index, snippets — got much faster:
 
 | Route       | Before   | After  |
-| ----------- | -------- | ------ |
+|-------------|----------|--------|
 | `/`         | 7,046 ms | 487 ms |
 | `/blog`     | 7,116 ms | 664 ms |
 | `/snippets` | 7,046 ms | 547 ms |
@@ -43,7 +43,7 @@ Roughly a 13x improvement. But the total build time didn't budge. Something else
 That something was `/blog/category/[category]`.
 
 | Metric           | Before       | After        |
-| ---------------- | ------------ | ------------ |
+|------------------|--------------|--------------|
 | Route total      | ~15.8 s      | ~45.8 s      |
 | Slowest category | ~1,000 ms    | ~6,600 ms    |
 | Typical range    | 900–1,100 ms | 500–6,600 ms |
@@ -108,7 +108,7 @@ highlighter — loading the WASM engine, two themes, and grammars for every bund
 
 The fix: use `@shikijs/rehype/core` with a single pre-created highlighter at module level.
 
-```typescript
+```js
 import rehypeShikiFromHighlighter from '@shikijs/rehype/core';
 import { bundledLanguages, getSingletonHighlighter } from 'shiki';
 
@@ -125,14 +125,15 @@ highlighter gets passed directly to each `compileMDX` call instead of creating a
 
 Same Vercel infrastructure, same 1 worker:
 
-| Metric                    | Before     | After      |
-| ------------------------- | ---------- | ---------- |
-| Static generation total   | 13.4 s     | 6.7 s      |
-| `/blog/category` route    | 45,771 ms  | 7,396 ms   |
-| Category per-page         | 6,663 ms   | 461 ms     |
-| `/blog/[slug]` route      | 43,168 ms  | 27,770 ms  |
+| Metric                  | Before    | After     |
+|-------------------------|-----------|-----------|
+| Static generation total | 13.4 s    | 6.7 s     |
+| `/blog/category` route  | 45,771 ms | 7,396 ms  |
+| Category per-page       | 6,663 ms  | 461 ms    |
+| `/blog/[slug]` route    | 43,168 ms | 27,770 ms |
 
-The category route dropped from 45.8s to 7.4s. Individual categories went from 6,663ms to 461ms. Static generation cut in half.
+The category route dropped from 45.8s to 7.4s. Individual categories went from 6,663ms to 461ms. Static generation cut
+in half.
 
 You might notice those route totals don't add up. Before the fix, `/blog/[slug]` showed 43s, `/blog/category` showed
 45s, `/snippets` showed 14s — that's 102 seconds of work. But actual static generation took 13.4s. The route times are

--- a/_posts/build-time-lies.md
+++ b/_posts/build-time-lies.md
@@ -11,7 +11,7 @@ keywords:
     static generation optimization,
     Vercel build logs,
   ]
-categories: [ Opinion, Tools, Vercel ]
+categories: [Opinion, Tools, Vercel]
 featured: false
 ---
 
@@ -33,7 +33,7 @@ Then I scrolled down to the per-page breakdown. Completely different story.
 The listing pages — homepage, blog index, snippets — got much faster:
 
 | Route       | Before   | After  |
-|-------------|----------|--------|
+| ----------- | -------- | ------ |
 | `/`         | 7,046 ms | 487 ms |
 | `/blog`     | 7,116 ms | 664 ms |
 | `/snippets` | 7,046 ms | 547 ms |
@@ -43,7 +43,7 @@ Roughly a 13x improvement. But the total build time didn't budge. Something else
 That something was `/blog/category/[category]`.
 
 | Metric           | Before       | After        |
-|------------------|--------------|--------------|
+| ---------------- | ------------ | ------------ |
 | Route total      | ~15.8 s      | ~45.8 s      |
 | Slowest category | ~1,000 ms    | ~6,600 ms    |
 | Typical range    | 900–1,100 ms | 500–6,600 ms |

--- a/_posts/build-time-lies.md
+++ b/_posts/build-time-lies.md
@@ -11,7 +11,7 @@ keywords:
     static generation optimization,
     Vercel build logs,
   ]
-categories: [ Opinion, Tools, Vercel ]
+categories: [Opinion, Tools, Vercel]
 featured: false
 ---
 
@@ -33,7 +33,7 @@ Then I scrolled down to the per-page breakdown. Completely different story.
 The listing pages — homepage, blog index, snippets — got much faster:
 
 | Route       | Before   | After  |
-|-------------|----------|--------|
+| ----------- | -------- | ------ |
 | `/`         | 7,046 ms | 487 ms |
 | `/blog`     | 7,116 ms | 664 ms |
 | `/snippets` | 7,046 ms | 547 ms |
@@ -43,7 +43,7 @@ Roughly a 13x improvement. But the total build time didn't budge. Something else
 That something was `/blog/category/[category]`.
 
 | Metric           | Before       | After        |
-|------------------|--------------|--------------|
+| ---------------- | ------------ | ------------ |
 | Route total      | ~15.8 s      | ~45.8 s      |
 | Slowest category | ~1,000 ms    | ~6,600 ms    |
 | Typical range    | 900–1,100 ms | 500–6,600 ms |
@@ -126,7 +126,7 @@ highlighter gets passed directly to each `compileMDX` call instead of creating a
 Same Vercel infrastructure, same 1 worker:
 
 | Metric                  | Before    | After     |
-|-------------------------|-----------|-----------|
+| ----------------------- | --------- | --------- |
 | Static generation total | 13.4 s    | 6.7 s     |
 | `/blog/category` route  | 45,771 ms | 7,396 ms  |
 | Category per-page       | 6,663 ms  | 461 ms    |

--- a/_posts/build-time-lies.md
+++ b/_posts/build-time-lies.md
@@ -52,7 +52,7 @@ Six categories jumped from about a second to 6.6 seconds each: `html`, `clean-co
 `advanced-react`. The rest stayed put. A 20-second improvement on listing pages masked a 30-second regression on
 category pages. Near-perfect cancellation.
 
-An accidental coincidence that made the top-line number useless.
+> An accidental coincidence that made the top-line number useless.
 
 ## The wrong fix
 
@@ -104,7 +104,7 @@ So why were the blog posts slow? I dug into the Shiki integration.
 Every `compileMDX` call created a new `rehypeShiki` plugin instance. Each instance initialized a fresh Shiki
 highlighter — loading the WASM engine, two themes, and grammars for every bundled language.
 
-**75 pages = 75 highlighter initializations.**
+> 75 pages = 75 highlighter initializations.
 
 The fix: use `@shikijs/rehype/core` with a single pre-created highlighter at module level.
 
@@ -138,8 +138,8 @@ You might notice those route totals don't add up. Before the fix, `/blog/[slug]`
 45s, `/snippets` showed 14s — that's 102 seconds of work. But actual static generation took 13.4s. The route times are
 concurrent, not sequential. Next.js generates multiple routes at the same time; each route's clock runs in parallel.
 
-The total build went from 46s to 42s because static generation is only one piece — TypeScript checking, Turbopack
-compilation, and Sentry uploads don't get faster when you fix Shiki.
+> The total build went from 46s to 42s because static generation is only one piece — TypeScript checking, Turbopack
+> compilation, and Sentry uploads don't get faster when you fix Shiki.
 
 ## Three things I got wrong
 

--- a/_posts/build-time-lies.md
+++ b/_posts/build-time-lies.md
@@ -122,9 +122,16 @@ const highlightCache = new Map();
 Themes and language grammars load once. A shared `Map` caches highlighted code blocks across pages. The pre-created
 highlighter gets passed directly to each `compileMDX` call instead of creating a new one.
 
-The category route dropped from 45.8s to 2.8s. Most categories now generate in under 363ms. But — honesty note — the "
-before" was measured on Vercel with 1 worker and the "after" was local with 13 workers. Two variables changed, not one.
-I trust the direction, not the exact ratio.
+Same Vercel infrastructure, same 1 worker:
+
+| Metric                    | Before     | After      |
+| ------------------------- | ---------- | ---------- |
+| Static generation total   | 13.4 s     | 6.7 s      |
+| `/blog/category` route    | 45,771 ms  | 7,396 ms   |
+| Category per-page         | 6,663 ms   | 461 ms     |
+| `/blog/[slug]` route      | 43,168 ms  | 27,770 ms  |
+
+The category route dropped from 45.8s to 7.4s. Individual categories went from 6,663ms to 461ms. Static generation cut in half.
 
 ## Three things I got wrong
 

--- a/_posts/build-time-lies.md
+++ b/_posts/build-time-lies.md
@@ -133,6 +133,8 @@ Same Vercel infrastructure, same 1 worker:
 
 The category route dropped from 45.8s to 7.4s. Individual categories went from 6,663ms to 461ms. Static generation cut in half.
 
+You might notice those route totals don't add up. Before the fix, `/blog/[slug]` showed 43s, `/blog/category` showed 45s, `/snippets` showed 14s — that's 102 seconds of work. But actual static generation took 13.4s. The route times are concurrent, not sequential. Next.js generates multiple routes at the same time; each route's clock runs in parallel. The total build went from 46s to 42s because static generation is only one piece — TypeScript checking, Turbopack compilation, and Sentry uploads don't get faster when you fix Shiki.
+
 ## Three things I got wrong
 
 First, I thought the category page was the problem. It wasn't — it was innocent bystander in a slow batch.

--- a/lib/posts/api.ts
+++ b/lib/posts/api.ts
@@ -168,7 +168,9 @@ export function filterPostsByCategory(
   );
 }
 
-export async function getPostsByCategory(category: string): Promise<Post[]> {
-  const posts = await getPosts();
-  return filterPostsByCategory(posts, category) as Post[];
+export async function getPostsByCategory(
+  category: string,
+): Promise<PostMetadata[]> {
+  const posts = await getPostsMetadata();
+  return filterPostsByCategory(posts, category) as PostMetadata[];
 }

--- a/lib/scripts/compiler.test.ts
+++ b/lib/scripts/compiler.test.ts
@@ -3,9 +3,13 @@ jest.mock('remark-gfm', () => jest.fn());
 jest.mock('rehype-slug', () => jest.fn());
 jest.mock('rehype-code-titles', () => jest.fn());
 jest.mock('rehype-autolink-headings', () => jest.fn());
-jest.mock('@shikijs/rehype', () => jest.fn());
+jest.mock('@shikijs/rehype/core', () => ({ default: jest.fn() }));
 jest.mock('@shikijs/transformers', () => ({
   transformerStyleToClass: jest.fn(() => ({})),
+}));
+jest.mock('shiki', () => ({
+  bundledLanguages: {},
+  getSingletonHighlighter: jest.fn(() => Promise.resolve({})),
 }));
 
 import { extractHeadingsFromMarkdown } from '@/lib/scripts/compiler';

--- a/lib/scripts/compiler.ts
+++ b/lib/scripts/compiler.ts
@@ -1,13 +1,22 @@
-import rehypeShiki from '@shikijs/rehype';
+import rehypeShikiFromHighlighter from '@shikijs/rehype/core';
 import { transformerStyleToClass } from '@shikijs/transformers';
 import { serialize } from 'next-mdx-remote/serialize';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeCodeTitles from 'rehype-code-titles';
 import rehypeSlug from 'rehype-slug';
 import remarkGfm from 'remark-gfm';
+import { bundledLanguages, getSingletonHighlighter } from 'shiki';
+
+const highlighterPromise = getSingletonHighlighter({
+  themes: ['github-light', 'github-dark'],
+  langs: Object.keys(bundledLanguages),
+});
+
+const highlightCache = new Map();
 
 export async function compileMDX(content: string) {
   const transformer = transformerStyleToClass();
+  const highlighter = await highlighterPromise;
 
   const mdx = await serialize(content, {
     mdxOptions: {
@@ -16,7 +25,8 @@ export async function compileMDX(content: string) {
         rehypeSlug,
         rehypeCodeTitles,
         [
-          rehypeShiki,
+          rehypeShikiFromHighlighter,
+          highlighter,
           {
             themes: {
               light: 'github-light',
@@ -24,6 +34,7 @@ export async function compileMDX(content: string) {
             },
             defaultColor: false,
             transformers: [transformer],
+            cache: highlightCache,
           },
         ],
         [

--- a/lib/scripts/compiler.ts
+++ b/lib/scripts/compiler.ts
@@ -12,10 +12,13 @@ const highlighterPromise = getSingletonHighlighter({
   langs: Object.keys(bundledLanguages),
 });
 
+// Singleton: highlightCache skips the transformer for cached blocks,
+// so a per-call transformer would return empty CSS on subsequent runs.
+// Module-level instance accumulates all class→variable mappings across calls.
+const transformer = transformerStyleToClass();
 const highlightCache = new Map();
 
 export async function compileMDX(content: string) {
-  const transformer = transformerStyleToClass();
   const highlighter = await highlighterPromise;
 
   const mdx = await serialize(content, {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "next-themes": "0.4.6",
     "react": "19.2.5",
     "react-dom": "19.2.5",
+    "shiki": "^4.0.2",
     "swr": "2.4.1"
   },
   "devDependencies": {

--- a/pages/blog/category/[category].tsx
+++ b/pages/blog/category/[category].tsx
@@ -6,14 +6,18 @@ import { BlogPostPreview } from '@/components/blog-post-preview';
 import { Categories } from '@/components/categories';
 import { NoResults } from '@/components/no-results';
 import { SearchInput } from '@/components/search-input';
-import { getPostsByCategory, getPostsCategories } from '@/lib/posts/api';
+import {
+  filterPostsByCategory,
+  getPostsCategories,
+  getPostsMetadata,
+} from '@/lib/posts/api';
 import { filterByHeading, sortByBirthtime } from '@/lib/posts/utils';
 import { generateBreadcrumbSchema } from '@/lib/schema';
-import { Post, PostCategory } from '@/lib/types';
+import { PostCategory, PostMetadata } from '@/lib/types';
 import { categoryToSeoData, formatCategoryName } from '@/lib/utils';
 
 interface CategoryPageProps {
-  posts: Post[];
+  posts: PostMetadata[];
   categories: PostCategory[];
   category: PostCategory;
   seoDescription: string;
@@ -134,8 +138,14 @@ export async function getStaticPaths() {
 export async function getStaticProps(
   context: GetStaticPropsContext,
 ): Promise<GetStaticPropsResult<CategoryPageProps>> {
-  const posts = await getPostsByCategory(context.params?.category as string);
-  const categories = await getPostsCategories();
+  const allPosts = await getPostsMetadata();
+  const categories = [
+    ...new Set(allPosts.flatMap((p) => p.data.categories)),
+  ] as PostCategory[];
+  const posts = filterPostsByCategory(
+    allPosts,
+    context.params?.category as string,
+  ) as PostMetadata[];
   const sortedPosts = posts.sort(sortByBirthtime);
   const postCategory = categories.find(
     (item) => item.toLowerCase() === context.params?.category,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       react-dom:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
+      shiki:
+        specifier: ^4.0.2
+        version: 4.0.2
       swr:
         specifier: 2.4.1
         version: 2.4.1(react@19.2.5)

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -139,6 +139,7 @@ html {
 }
 
 .dark .shiki {
+  --shiki-dark-bg: #121212;
   background-color: var(--shiki-dark-bg, #24292e);
 }
 


### PR DESCRIPTION
Category page never uses post content — only slug, heading, and description. Switch getPostsByCategory from getPosts (full content) to getPostsMetadata, and inline a single getPostsMetadata call in getStaticProps to halve file reads from 66 to 33 per category.

Fixes +33s build regression on /blog/category/[category] caused by Shiki worker contention after @shikijs/transformers was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Content**
  * Added a new blog post explaining build-time findings and fixes.

* **Refactor**
  * Optimized category page data handling and static generation for faster builds and smaller page payloads.
  * Improved MDX/code highlighting pipeline to reduce build and per-page generation times.

* **Style**
  * Updated dark-mode code block background for improved contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->