### PR TITLE
perf: slim list pages static props payloads

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = { src: '/file-stub', height: 1, width: 1 };

--- a/__tests__/static-props-payload.test.tsx
+++ b/__tests__/static-props-payload.test.tsx
@@ -66,7 +66,11 @@ describe('list pages static props payload', () => {
     expect(snippets.length).toBeGreaterThan(0);
     for (const snippet of snippets) {
       expect(snippet).not.toHaveProperty('content');
-      expect(snippet.data.heading).toEqual(expect.any(String));
+      expect(Object.keys(snippet.data).sort()).toEqual([
+        'createDate',
+        'heading',
+        'slug',
+      ]);
     }
     expect(jsonLd).toHaveProperty('@type', 'CollectionPage');
   });

--- a/__tests__/static-props-payload.test.tsx
+++ b/__tests__/static-props-payload.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react';
+
+import { PostCategory, PostMetadata, SnippetMetadata } from '@/lib/types';
+import IndexPage, {
+  getStaticProps as getIndexStaticProps,
+} from '@/pages/index';
+import SnippetsPage, {
+  getStaticProps as getSnippetsStaticProps,
+} from '@/pages/snippets';
+
+const makePost = (slug: string, featured = false): PostMetadata => ({
+  data: {
+    slug,
+    title: `${slug} title`,
+    heading: `${slug} heading`,
+    description: `${slug} description`,
+    createDate: 1700000000000,
+    keywords: [],
+    updateDate: null,
+    readTime: '3 min read',
+    featured,
+    categories: featured ? [PostCategory.JS] : [PostCategory.AdvancedReact],
+  },
+});
+
+const makeSnippet = (slug: string): SnippetMetadata => ({
+  data: {
+    slug,
+    title: `${slug} title`,
+    heading: `${slug} heading`,
+    description: `${slug} description`,
+    createDate: 1700000000000,
+    keywords: [],
+    updateDate: null,
+  },
+});
+
+describe('list pages static props payload', () => {
+  test('homepage props contain post metadata only, no content', async () => {
+    const result = await getIndexStaticProps();
+
+    if (!('props' in result)) {
+      throw new Error('expected getStaticProps to return props');
+    }
+
+    const { featuredPosts, otherPosts, advancedReactPosts } = result.props;
+    const allPosts = [...featuredPosts, ...otherPosts, ...advancedReactPosts];
+
+    expect(allPosts.length).toBeGreaterThan(0);
+    for (const post of allPosts) {
+      expect(post).not.toHaveProperty('content');
+      expect(post.data.slug).toEqual(expect.any(String));
+      expect(post.data.heading).toEqual(expect.any(String));
+    }
+  });
+
+  test('snippets page props contain snippet metadata only, no content', async () => {
+    const result = await getSnippetsStaticProps();
+
+    if (!('props' in result)) {
+      throw new Error('expected getStaticProps to return props');
+    }
+
+    const { snippets, jsonLd } = result.props;
+
+    expect(snippets.length).toBeGreaterThan(0);
+    for (const snippet of snippets) {
+      expect(snippet).not.toHaveProperty('content');
+      expect(snippet.data.heading).toEqual(expect.any(String));
+    }
+    expect(jsonLd).toHaveProperty('@type', 'CollectionPage');
+  });
+});
+
+describe('list pages render from metadata-only props', () => {
+  test('homepage renders post headings', () => {
+    render(
+      <IndexPage
+        featuredPosts={[makePost('feat-one', true)]}
+        otherPosts={[makePost('other-one')]}
+        advancedReactPosts={[makePost('react-one')]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Serhii Shramko' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('feat-one heading')).toBeInTheDocument();
+    expect(screen.getByText('react-one heading')).toBeInTheDocument();
+    expect(screen.getByText('other-one heading')).toBeInTheDocument();
+  });
+
+  test('snippets page renders snippet cards', () => {
+    render(
+      <SnippetsPage snippets={[makeSnippet('use-debounce')]} jsonLd={{}} />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Code Snippets' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('use-debounce heading')).toBeInTheDocument();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,6 +22,7 @@ const config = {
     '^@/pages/(.*)$': '<rootDir>/pages/$1',
     '^@/lib/(.*)$': '<rootDir>/lib/$1',
     '^lib/prisma$': '<rootDir>/lib/prisma',
+    '\\.(webp|png|jpe?g|gif|svg|ico)$': '<rootDir>/__mocks__/fileMock.js',
     '\\.(css)$': '<rootDir>/__mocks__/styleMock.js',
   },
   testPathIgnorePatterns: ['/node_modules/', '/.next/', '/__tests__/helpers/'],

--- a/lib/posts/api.test.ts
+++ b/lib/posts/api.test.ts
@@ -5,7 +5,6 @@ import matter from 'gray-matter';
 import {
   filterPostsByCategory,
   getPostBySlug,
-  getPosts,
   getPostsCategories,
   getPostsMetadata,
   getPostSlugs,
@@ -198,43 +197,6 @@ describe('Posts API', () => {
       await expect(getPostBySlug('broken')).rejects.toThrow(
         /Invalid markdown format/,
       );
-    });
-  });
-
-  describe('getPosts', () => {
-    it('should ignore non-markdown files in the posts directory', async () => {
-      (readdir as jest.Mock).mockResolvedValueOnce([
-        'a.md',
-        '.DS_Store',
-        'README.txt',
-        'b.md',
-      ]);
-      (readFile as jest.Mock).mockResolvedValue('content');
-
-      const posts = await getPosts();
-
-      expect(posts).toHaveLength(2);
-      expect(posts.map((p) => p.data.slug)).toEqual(['a', 'b']);
-    });
-
-    it('should return both data and content for each post', async () => {
-      (readdir as jest.Mock).mockResolvedValueOnce(['only.md']);
-      (readFile as jest.Mock).mockResolvedValueOnce('raw markdown');
-
-      const [post] = await getPosts();
-
-      expect(post).toEqual(
-        expect.objectContaining({
-          data: expect.objectContaining({ slug: 'only' }),
-          content: 'Test content',
-        }),
-      );
-    });
-
-    it('should return empty array when directory is empty', async () => {
-      (readdir as jest.Mock).mockResolvedValueOnce([]);
-
-      await expect(getPosts()).resolves.toEqual([]);
     });
   });
 

--- a/lib/posts/api.ts
+++ b/lib/posts/api.ts
@@ -77,19 +77,6 @@ export async function getPostBySlug(slug?: string): Promise<Post> {
   }
 }
 
-export async function getPosts(): Promise<Post[]> {
-  const fileNames = await readdir(POSTS_DIRECTORY);
-  const markdownFiles = fileNames.filter((fileName) =>
-    fileName.endsWith('.md'),
-  );
-
-  const postPromises = markdownFiles
-    .map(extractMarkdownSlug)
-    .map(getPostBySlug);
-
-  return Promise.all(postPromises);
-}
-
 export async function getPostsMetadata(): Promise<PostMetadata[]> {
   const fileNames = await readdir(POSTS_DIRECTORY);
   const markdownFiles = fileNames.filter((fileName) =>

--- a/lib/posts/utils.ts
+++ b/lib/posts/utils.ts
@@ -1,8 +1,14 @@
-import { Post, PostCategory, PostMetadata, Snippet } from '@/lib/types';
+import {
+  Post,
+  PostCategory,
+  PostMetadata,
+  Snippet,
+  SnippetMetadata,
+} from '@/lib/types';
 
 export const sortByBirthtime = (
-  first: Post | PostMetadata | Snippet,
-  second: Post | PostMetadata | Snippet,
+  first: Post | PostMetadata | Snippet | SnippetMetadata,
+  second: Post | PostMetadata | Snippet | SnippetMetadata,
 ) => second.data.createDate - first.data.createDate;
 
 export const filterByFeatured = (post: Post | PostMetadata) =>

--- a/lib/snippets/api.test.ts
+++ b/lib/snippets/api.test.ts
@@ -1,0 +1,47 @@
+import {
+  getSnippetBySlug,
+  getSnippetSlugs,
+  getSnippetsMetadata,
+} from '@/lib/snippets/api';
+
+describe('Snippets API', () => {
+  describe('getSnippetsMetadata', () => {
+    it('returns one metadata entry per snippet file, without content', async () => {
+      const slugs = await getSnippetSlugs();
+      const snippets = await getSnippetsMetadata();
+
+      expect(snippets).toHaveLength(slugs.length);
+      expect(snippets.length).toBeGreaterThan(0);
+
+      for (const snippet of snippets) {
+        expect(snippet).not.toHaveProperty('content');
+        expect(snippet.data.slug).toEqual(expect.any(String));
+        expect(snippet.data.heading).toEqual(expect.any(String));
+        expect(snippet.data.createDate).toEqual(expect.any(Number));
+      }
+    });
+  });
+
+  describe('getSnippetBySlug', () => {
+    it('returns both data and content for a real snippet', async () => {
+      const [slug] = await getSnippetSlugs();
+      const snippet = await getSnippetBySlug(slug);
+
+      expect(snippet.data.slug).toBe(slug);
+      expect(snippet.content).toEqual(expect.any(String));
+      expect(snippet.content.length).toBeGreaterThan(0);
+    });
+
+    it('throws when slug is missing', async () => {
+      await expect(getSnippetBySlug()).rejects.toThrow(
+        'getSnippetBySlug: slug is required',
+      );
+    });
+
+    it('throws a wrapped error for a nonexistent slug', async () => {
+      await expect(
+        getSnippetBySlug('definitely-not-a-real-snippet'),
+      ).rejects.toThrow('ENOENT');
+    });
+  });
+});

--- a/lib/snippets/api.ts
+++ b/lib/snippets/api.ts
@@ -3,53 +3,71 @@ import { join } from 'path';
 
 import matter from 'gray-matter';
 
-import { Snippet } from '@/lib/types';
+import { Snippet, SnippetMetadata } from '@/lib/types';
 import { extractMarkdownSlug } from '@/lib/utils';
 
 const SNIPPETS_DIRECTORY = join(process.cwd(), '_snippets');
 
+async function readSnippetFile(slug: string) {
+  const fullPath = join(SNIPPETS_DIRECTORY, `${slug}.md`);
+  const fileContents = await readFile(fullPath, 'utf8');
+
+  return matter(fileContents);
+}
+
+function buildSnippetData(
+  slug: string,
+  matterResult: matter.GrayMatterFile<string>,
+): Snippet['data'] {
+  const {
+    data: { title, heading, description, createDate, updateDate, keywords },
+  } = matterResult;
+
+  return {
+    slug,
+    title,
+    heading,
+    description,
+    keywords,
+    createDate: Date.parse(createDate),
+    updateDate: updateDate ? Date.parse(updateDate) : null,
+  };
+}
+
 export async function getSnippetBySlug(slug?: string): Promise<Snippet> {
   if (!slug) {
-    throw new Error('getPostBySlug: slug is required');
+    throw new Error('getSnippetBySlug: slug is required');
   }
 
   try {
-    const fullPath = join(SNIPPETS_DIRECTORY, `${slug}.md`);
-    const fileContents = await readFile(fullPath, 'utf8');
-
-    const {
-      data: { title, heading, description, createDate, updateDate, keywords },
-      content,
-    } = matter(fileContents);
+    const matterResult = await readSnippetFile(slug);
 
     return {
-      data: {
-        slug,
-        title,
-        heading,
-        description,
-        keywords,
-        createDate: Date.parse(createDate),
-        updateDate: updateDate ? Date.parse(updateDate) : null,
-      },
-      content,
+      data: buildSnippetData(slug, matterResult),
+      content: matterResult.content,
     };
   } catch (err) {
     throw new Error(String(err), { cause: err });
   }
 }
 
-export async function getSnippets(): Promise<Snippet[]> {
+async function getSnippetMetadataBySlug(
+  slug: string,
+): Promise<SnippetMetadata> {
+  const matterResult = await readSnippetFile(slug);
+
+  return { data: buildSnippetData(slug, matterResult) };
+}
+
+export async function getSnippetsMetadata(): Promise<SnippetMetadata[]> {
   const fileNames = await readdir(SNIPPETS_DIRECTORY);
   const markdownFiles = fileNames.filter((fileName) =>
     fileName.endsWith('.md'),
   );
 
-  const snippetPromises = markdownFiles
-    .map(extractMarkdownSlug)
-    .map(getSnippetBySlug);
-
-  return Promise.all(snippetPromises);
+  return Promise.all(
+    markdownFiles.map(extractMarkdownSlug).map(getSnippetMetadataBySlug),
+  );
 }
 
 export async function getSnippetSlugs(): Promise<string[]> {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -66,6 +66,8 @@ export type Snippet = {
   content: string;
 };
 
+export type SnippetMetadata = Omit<Snippet, 'content'>;
+
 type LinkedinCompany = {
   name: string;
   url: string;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,7 @@ import useSWR from 'swr';
 
 import { BlogPostSquarePreview } from '@/components/blog-post-square-preview';
 import { fetcher } from '@/lib/fetcher';
-import { getPosts } from '@/lib/posts/api';
+import { getPostsMetadata } from '@/lib/posts/api';
 import {
   filterByAdvanceReact,
   filterByFeatured,
@@ -18,7 +18,7 @@ import {
 } from '@/lib/posts/utils';
 import { Routes } from '@/lib/routes';
 import { generateWebSiteSchema } from '@/lib/schema';
-import { Post } from '@/lib/types';
+import { PostMetadata } from '@/lib/types';
 import { generateGradient } from '@/lib/utils';
 import type { AllViewsResponse } from '@/pages/api/views';
 
@@ -26,9 +26,9 @@ import smile from '../public/static/images/smile.webp';
 import tongue from '../public/static/images/tongue.webp';
 
 interface IndexPageProps {
-  featuredPosts: Post[];
-  otherPosts: Post[];
-  advancedReactPosts: Post[];
+  featuredPosts: PostMetadata[];
+  otherPosts: PostMetadata[];
+  advancedReactPosts: PostMetadata[];
 }
 
 function IndexPage(props: IndexPageProps) {
@@ -250,7 +250,7 @@ function IndexPage(props: IndexPageProps) {
 export async function getStaticProps(): Promise<
   GetStaticPropsResult<IndexPageProps>
 > {
-  const posts = await getPosts();
+  const posts = await getPostsMetadata();
   const otherPosts = posts
     .filter(filterByNotFeatured)
     .sort(sortByBirthtime)

--- a/pages/snippets/index.tsx
+++ b/pages/snippets/index.tsx
@@ -2,11 +2,11 @@ import Head from 'next/head';
 
 import { ResourceCard } from '@/components/resource-card';
 import { sortByBirthtime } from '@/lib/posts/utils';
-import { getSnippets } from '@/lib/snippets/api';
-import { Snippet } from '@/lib/types';
+import { getSnippetsMetadata } from '@/lib/snippets/api';
+import { SnippetMetadata } from '@/lib/types';
 
 interface SnippetsPageProps {
-  snippets: Snippet[];
+  snippets: SnippetMetadata[];
   jsonLd: object;
 }
 
@@ -73,7 +73,7 @@ function SnippetsPage(props: SnippetsPageProps) {
 }
 
 export async function getStaticProps() {
-  const snippets = await getSnippets();
+  const snippets = await getSnippetsMetadata();
   const sortedSnippets = snippets.sort(sortByBirthtime);
 
   const jsonLd = {

--- a/pages/snippets/index.tsx
+++ b/pages/snippets/index.tsx
@@ -5,8 +5,12 @@ import { sortByBirthtime } from '@/lib/posts/utils';
 import { getSnippetsMetadata } from '@/lib/snippets/api';
 import { SnippetMetadata } from '@/lib/types';
 
+type SnippetListItem = {
+  data: Pick<SnippetMetadata['data'], 'slug' | 'heading' | 'createDate'>;
+};
+
 interface SnippetsPageProps {
-  snippets: SnippetMetadata[];
+  snippets: SnippetListItem[];
   jsonLd: object;
 }
 
@@ -126,7 +130,11 @@ export async function getStaticProps() {
 
   return {
     props: {
-      snippets: sortedSnippets,
+      snippets: sortedSnippets.map(
+        ({ data: { slug, heading, createDate } }) => ({
+          data: { slug, heading, createDate },
+        }),
+      ),
       jsonLd,
     },
   };


### PR DESCRIPTION
## Summary

- homepage and /snippets serialized full markdown content into route-data JSON while rendering only heading/slug/date; both now use metadata-only APIs (index.json 22.2 KB → 2.1 KB gzip; snippets.json 41.6 KB → 3.8 KB gzip, a 91% cut)
- adds getSnippetsMetadata + SnippetMetadata type; deletes now-dead getPosts/getSnippets; regression test asserts list-page props contain no content
- snippets list props are additionally narrowed at the page boundary to the fields the page renders (slug/heading/createDate); JSON-LD still builds from full metadata; regression test pins the exact key set

## Type

- [x] perf — performance

## Linked spec or plan

docs/superpowers/specs/2026-07-19-perf-audit-response-design.md (local, gitignored) — Component 1: Payload diet.

## Test plan

- [x] `pnpm verify:full` exits 0 locally
- [x] new regression test: list-page getStaticProps payloads contain no `content` field; snippets list items contain exactly slug/heading/createDate
- [x] measured post-build: index.json 2.1 KB gzip (target ≤5 KB, met)
- [x] measured post-build: snippets.json 3.8 KB gzip (target ≤5 KB, met)

## Breaking changes

None